### PR TITLE
Make belongs_to relationship presence optional

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -34,6 +34,7 @@ module Devise
         else
           {:polymorphic => true}
         end
+        belongs_to_options[:optional] = true
         if fk = Devise.invited_by_foreign_key
           belongs_to_options[:foreign_key] = fk
         end


### PR DESCRIPTION
Mongoid 6 makes belongs to relationships mandatory by default.
